### PR TITLE
Adds WATCH feature

### DIFF
--- a/docs/API.rst
+++ b/docs/API.rst
@@ -150,6 +150,27 @@ Client
         generating the whois information and is passed exactly the same
         information as a `whois` event described above.
 
+.. js:function:: Client.watchRaw(nicks, [mode])
+
+    Adds or removes the specified `nicks` to the watch list. Notifications from the server are available via the `watch`, `watchlist`, `watchonline` and `watchoffline` events.
+
+    :param string nicks: is a nickname or an array of nicknames. Nicknames should contain the `+` (add) or `-` (remove) prefixes
+    :param string mode: is the mode to use for the watch list (`s` or `l`). Defaults to `s`
+
+.. js:function:: Client.watch(nicks, [mode])
+
+    Adds the specified `nicks` to the watch list. Notifications from the server are available via the `watch`, `watchlist`, `watchonline` and `watchoffline` events.
+
+    :param string nicks: is a nickname or an array of nicknames.
+    :param string mode: is the mode to use for the watch list (`s` or `l`). Defaults to `s`
+
+.. js:function:: Client.unwatch(nicks, [mode])
+
+    Removes the specified `nicks` to the watch list.
+
+    :param string nicks: is a nickname or an array of nicknames.
+    :param string mode: is the mode to use for the watch list (`s` or `l`). Defaults to `s`
+
 .. js:function:: Client.list([arg1, arg2, ...])
 
    Request a channel listing from the server. The arguments for this method are
@@ -444,6 +465,64 @@ Events
             serverinfo: "The Dollyfish Underworld",
             operator: "is an IRC Operator"
         }
+
+.. js:data:: 'watch'
+
+    `function (message) { }`
+
+    Emitted whenever the server sees or stops seeing a nickname in the watch list. The
+    information should look something like::
+
+        // when user goes online:
+        {
+            "prefix":"calisto.chathispano.com",
+            "server":"calisto.chathispano.com",
+            "command":"rpl_watchoffline",
+            "rawCommand":"600",
+            "commandType":"reply",
+            "args":[
+                "asdfoiuqwoer__1", // this is our nickname
+                "aaaaa5", // here goes the nickname in our watch list
+                "joqiwjelkj",
+                "D6huCU.AWxGvE.virtual",
+                "1561727250",
+                "logged online"
+            ]
+        }
+        // when user goes offline:
+        {
+            "prefix":"calisto.chathispano.com",
+            "server":"calisto.chathispano.com",
+            "command":"rpl_watchoffline",
+            "rawCommand":"601",
+            "commandType":"reply",
+            "args":[
+                "asdfoiuqwoer__1", // this is our nickname
+                "aaaaa5", // here goes the nickname in our watch list
+                "joqiwjelkj",
+                "D6huCU.AWxGvE.virtual",
+                "1561727250",
+                "logged offline"
+            ]
+        }
+
+.. js:data:: 'watchonline'
+
+    `function (nickname) { }`
+
+    Emitted whenever `nickname` in our watch list goes online
+
+.. js:data:: 'watchoffline'
+
+    `function (nickname) { }`
+
+    Emitted whenever `nickname` in our watch list goes offline
+
+.. js:data:: 'watchlist'
+
+    `function (nicknames) { }`
+
+    Emitted whenever the watch list is updated after calling `watch` or `unwatch` functions. `nicknames` is an array with the nicknames in our watching list
 
 .. js:data:: 'channellist_start'
 

--- a/lib/codes.js
+++ b/lib/codes.js
@@ -550,6 +550,26 @@ module.exports = {
         name: 'err_usersdontmatch',
         type: 'error',
     },
+    600: {
+        name: 'rpl_watchonline',
+        type: 'reply'
+    },
+    601: {
+        name: 'rpl_watchoffline',
+        type: 'reply'
+    },
+    604: {
+        name: 'rpl_watchonline',
+        type: 'reply'
+    },
+    605: {
+        name: 'rpl_watchoffline',
+        type: 'reply'
+    },
+    606: {
+        name: 'rpl_watchlist',
+        type: 'reply'
+    },
     671: {
         name: 'rpl_whoissecure',
         type: 'reply',

--- a/lib/handleRaw.js
+++ b/lib/handleRaw.js
@@ -126,6 +126,9 @@ const rplIsupport = (message, client) => {
             case 'TOPICLEN':
                 client.supported.topiclength = parseInt(value);
             break;
+            case 'WATCH':
+                client.supported.watchLength = parseInt(value);
+            break;
         }
         }
     });
@@ -620,6 +623,16 @@ const rplEndofmotd = (message, client) => {
     client.emit('motd', client.motd);
 };
 
+const rplWatch = (message, client) => {
+    if (message.command === 'rpl_watchonline') client.emit('watchonline', message.args[1]);
+    if (message.command === 'rpl_watchoffline') client.emit('watchoffline', message.args[1]);
+    client.emit('watch', message);
+};
+
+const rplWatchList = (message, client) => {
+    client.emit('watchlist', message.args[1].split(' '))
+}
+
 const errorHandler = (message, client) => client.emit('error', message);
 
 const defaultHandler = (message, client) => {
@@ -722,6 +735,11 @@ module.exports = (message, client) => {
         return rplYouroper(message, client);
     case 'rpl_chanforward':
         return rplChanForward(message, client);
+    case 'rpl_watchonline':
+    case 'rpl_watchoffline':
+        return rplWatch(message, client);
+    case 'rpl_watchlist':
+        return rplWatchList(message, client);
     case 'PING':
         return ping(message, client);
     case 'PONG':

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -871,6 +871,31 @@ Client.prototype.whoisPromise = function (nick) {
     });
 };
 
+// Sets nicks watching list. Nicks are used as they come
+Client.prototype.watchRaw = function (nicks, mode) {
+    if (!_.isArray(nicks)) nicks = [nicks];
+    mode = mode || 's';
+    this.send('WATCH', nicks.join(' '), mode);
+};
+
+// Adds nicks to the watching list, '+' symbol is added to passed nicks
+Client.prototype.watch = function (nicks, mode) {
+    if (!_.isArray(nicks)) nicks = [nicks];
+    this.watchRaw(
+      nicks.map(nick => `+${nick}`),
+      mode
+    )
+};
+
+// Removes nicks from the watching list, '-' symbol is added to passed nicks
+Client.prototype.unwatch = function (nicks, mode) {
+    if (!_.isArray(nicks)) nicks = [nicks];
+    this.watchRaw(
+      nicks.map(nick => `-${nick}`),
+      mode
+    )
+};
+
 // TODO END ADD TO DOCUEMTNATION
 
 // Ping Counter


### PR DESCRIPTION
Although it's described in the RFC, the `WATCH` command is widely supported and I needed it in my project, so I just implemented it following the package logic as far as I could.

Feel free to merge it if you think it would a good choice. In case of wanting just to be 100% compliant with the RFC, what about a non-RFC compliant branch for functionalities like this?

Issue 1: I added the code to get the `WATCH` param from the supported reply [here][1], but checking it in the [watchRaw function][2] doesn't make sense unless adding an event fired when the supported data has been read (and didn't want to mess with that while implementing this).

Issue 2: I updated the docs to include functions and events implemented here, but couldn't test it as my `rst2html` command was throwing some error about unsupported syntax.

[1]: https://github.com/luixal/node-irc/blob/9c929a9a6fa3c4ecd158658baadc634d4eedab9d/lib/handleRaw.js#L129
[2]: https://github.com/luixal/node-irc/blob/9c929a9a6fa3c4ecd158658baadc634d4eedab9d/lib/irc.js#L875